### PR TITLE
FIX stop travis adding bad requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,13 @@ before_script:
 
   # Install composer dependencies
   - composer validate
-  - composer require --no-update silverstripe/recipe-cms:1.0.x-dev
   - if [[ $CRONTASK ]]; then composer require --no-update silverstripe/crontask ^2; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs src/ tests/ *.php; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs src/ tests/; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi


### PR DESCRIPTION
Since CWP 2.0.0-rc1 travis has trouble resolving an installable set of
dependencies due to CWP requiring SilverStripe core 4.1, but the line in
the travis config reuqiring 4.0. This line is actually unnecessary - the
module's own requirements are suffcient for successfully running the test
suite.