### PR TITLE
API Rename doUnpublish to onAfterUnpublish to prevent collisions with Versioned

### DIFF
--- a/src/Extensions/PdfExportExtension.php
+++ b/src/Extensions/PdfExportExtension.php
@@ -87,7 +87,7 @@ class PdfExportExtension extends DataExtension
     /**
      * Remove linked pdf when unpublishing the page, so it's no longer valid.
      */
-    public function doUnpublish()
+    public function onAfterUnpublish()
     {
         $filepath = $this->getPdfFilename();
         if (file_exists($filepath)) {


### PR DESCRIPTION
The way it is currently named overrides `Versioned::doUnpublish` from actually working, updated to be extensible.