### PR TITLE
FIX Generated PDF assets are now stored in the public assets folder if configured

### DIFF
--- a/src/Extensions/PdfExportExtension.php
+++ b/src/Extensions/PdfExportExtension.php
@@ -2,6 +2,7 @@
 
 namespace CWP\PDFExport\Extensions;
 
+use SilverStripe\Assets\File;
 use SilverStripe\Control\Director;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\Versioned\Versioned;
@@ -49,8 +50,8 @@ class PdfExportExtension extends DataExtension
         $baseName = sprintf('%s-%s', $this->owner->URLSegment, $this->owner->ID);
 
         $folderPath = $this->owner->config()->get('generated_pdf_path');
-        if ($folderPath[0] != '/') {
-            $folderPath = BASE_PATH . '/' . $folderPath;
+        if ($folderPath[0] !== '/') {
+            $folderPath = File::join_paths(Director::publicFolder(), $folderPath);
         }
 
         return sprintf('%s/%s.pdf', $folderPath, $baseName);

--- a/tests/Extensions/PdfExportExtensionTest.php
+++ b/tests/Extensions/PdfExportExtensionTest.php
@@ -4,6 +4,7 @@ namespace CWP\PDFExport\Tests\Extensions;
 
 use CWP\CWP\PageTypes\BasePage;
 use CWP\PDFExport\Extensions\PdfExportExtension;
+use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 
@@ -26,14 +27,29 @@ class PdfExportExtensionTest extends SapphireTest
             ->set(BasePage::class, 'generated_pdf_path', 'assets/_generated_pdfs');
     }
 
-    public function testPdfFilename()
+    /**
+     * @param string $publicDir
+     * @param string $expected
+     * @dataProvider pdfFilenameProvider
+     */
+    public function testPdfFilenameWithoutPublicDirectory($publicDir, $expected)
     {
+        Director::config()->set('alternate_public_dir', $publicDir);
+
+        /** @var BasePage|PdfExportExtension $page $page */
         $page = $this->objFromFixture(BasePage::class, 'test-page-one');
-        $this->assertContains(
-            'assets/_generated_pdfs/test-page-one-1.pdf',
-            $page->getPdfFilename(),
-            'Generated filename for PDF'
-        );
+        $this->assertContains($expected, $page->getPdfFilename());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function pdfFilenameProvider()
+    {
+        return [
+            'no public folder' => ['', 'assets/_generated_pdfs/test-page-one-1.pdf'],
+            'public folder' => ['public', 'public/assets/_generated_pdfs/test-page-one-1.pdf'],
+        ];
     }
 
     public function testPdfLink()


### PR DESCRIPTION
Was previously creating a new assets folder in the project root folder to store them in.

Fixes #8