### PR TITLE
Update the generated_pdf_path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,6 @@
         "phpunit/phpunit": "^5.7",
         "squizlabs/php_codesniffer": "^3"
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.x-dev"
-        }
-    },
     "autoload": {
         "psr-4": {
             "CWP\\PDFExport\\": "src/",

--- a/src/Extensions/PdfExportExtension.php
+++ b/src/Extensions/PdfExportExtension.php
@@ -42,7 +42,7 @@ class PdfExportExtension extends DataExtension
      * @config
      * @var string
      */
-    private static $generated_pdf_path = 'assets/_generated_pdfs';
+    private static $generated_pdf_path = 'public/assets/_generated_pdfs';
 
     /**
      * Return the full filename of the pdf file, including path & extension


### PR DESCRIPTION
I've been having issues with deploying to UAT for a recent project, turns out that the issue stems from the `private static $generated_pdf_path`, which references the SS3 asset path. I have changed this to `public/assets/_generated_pdfs `.