### PR TITLE
Replace BASE_PATH with PUBLIC_PATH

### DIFF
--- a/src/Tasks/CleanupGeneratedPdfBuildTask.php
+++ b/src/Tasks/CleanupGeneratedPdfBuildTask.php
@@ -17,7 +17,7 @@ class CleanupGeneratedPdfBuildTask extends BuildTask
 
     public function run($request)
     {
-        $path = sprintf('%s/%s', BASE_PATH, BasePage::config()->get('generated_pdf_path'));
+        $path = sprintf('%s/%s', PUBLIC_PATH, BasePage::config()->get('generated_pdf_path'));
         if (!file_exists($path)) {
             return false;
         }


### PR DESCRIPTION
In SS4 the assets folder is not neccessarily in the root of the base path.