### PR TITLE
ENH Do not show icon if binary is not available

### DIFF
--- a/src/Extensions/PdfExportControllerExtension.php
+++ b/src/Extensions/PdfExportControllerExtension.php
@@ -12,6 +12,7 @@ use SilverStripe\Core\Environment;
 use SilverStripe\Core\Extension;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Dev\Deprecation;
+use SilverStripe\CMS\Controllers\ContentController;
 
 class PdfExportControllerExtension extends Extension
 {
@@ -28,6 +29,10 @@ class PdfExportControllerExtension extends Extension
     {
         if (!$this->owner->data()->config()->get('pdf_export')) {
             return false;
+        }
+        $binaryPath = $this->getBinaryPath();
+        if (!$binaryPath) {
+            return HTTPResponse::create('PDF download is not available', 400);
         }
 
         // We only allow producing live pdf. There is no way to secure the draft files.
@@ -80,12 +85,7 @@ class PdfExportControllerExtension extends Extension
         return $proxy;
     }
 
-    /**
-     * Render the page as PDF using wkhtmltopdf.
-     *
-     * @return HTTPResponse|false
-     */
-    public function generatePDF()
+    private function getBinaryPath()
     {
         if (!$this->owner->data()->config()->get('pdf_export')) {
             return false;
@@ -105,7 +105,20 @@ class PdfExportControllerExtension extends Extension
                 $binaryPath = Environment::getEnv('WKHTMLTOPDF_BINARY');
             }
         }
+        return $binaryPath;
+    }
 
+    /**
+     * Render the page as PDF using wkhtmltopdf.
+     *
+     * @return HTTPResponse|false
+     */
+    public function generatePDF()
+    {
+        if (!$this->owner->data()->config()->get('pdf_export')) {
+            return false;
+        }
+        $binaryPath = $this->getBinaryPath();
         if (!$binaryPath) {
             user_error(
                 'Neither WKHTMLTOPDF_BINARY nor ' . get_class($this->owner->data()) . '.wkhtmltopdf_binary are defined',

--- a/tests/Extensions/PdfExportExtensionTest.php
+++ b/tests/Extensions/PdfExportExtensionTest.php
@@ -24,7 +24,8 @@ class PdfExportExtensionTest extends SapphireTest
 
         Config::modify()
             ->set(BasePage::class, 'pdf_export', true)
-            ->set(BasePage::class, 'generated_pdf_path', 'assets/_generated_pdfs');
+            ->set(BasePage::class, 'generated_pdf_path', 'assets/_generated_pdfs')
+            ->set(BasePage::class, 'bypass_pdf_binary_check', true);
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/613

Code is copied from https://github.com/silverstripe/cwp-pdfexport/blob/1.4/src/Extensions/PdfExportControllerExtension.php#L98

I didn't use a static helper function due to the use of `$this->owner->config()->get('wkhtmltopdf_binary');`

I think code duplication is fine in this context